### PR TITLE
fix: skip updating a commit status when env.COMMIT_STATUS_SHA is empty

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,7 @@ runs:
   using: composite
   steps:
     - uses: suzuki-shunsuke/update-commit-status-action@main
+      if: env.GHA_COMMIT_STATUS_SHA
       with:
         repo_owner: ${{env.GHA_REPOSITORY_OWNER}}
         repo_name: ${{env.MAIN_REPO_NAME}}


### PR DESCRIPTION
- https://github.com/gha-trigger/start-action/pull/6